### PR TITLE
Misc

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,117 +27,22 @@ it depends on:
 + [CSSStyleSheet constructor](https://caniuse.com/mdn-api_cssstylesheet_cssstylesheet)
 + [ElementInternals](https://caniuse.com/mdn-api_elementinternals)
 
-## Project Status
-This project is in a _very early_ stage and the API is likely to change
-in the future.  Use at your own risk.  Not available in a package
-repo yet, [use the SHA](https://clojure.org/news/2018/01/05/git-deps).
+## Learning
+Zero is in a highly experimental stage of development, as such, it's
+difficult to keep any sort of extensive documentation up to date.  So
+I've built a few demos, and will try to keep those up to date with
+the latest Zero version.
+- [TodoMVC](https://github.com/raystubbs/zero-todomvc)
+- [SSR Demo (w. live updates)](https://github.com/raystubbs/zero-ssr-demo)
 
-## Organization
-- `zero.core` has all the essentials
-- `zero.extras.*` has optional QoL utilities
-
-## Examples
-Zero allows you to build native web components with a [Hiccup][hiccup]-like
-notation.  Here's what that looks like:
-
-```clojure
-(defn my-view [{:keys [heading]}]
-  [:section.some-class
-   [:h3 heading]
-   [:p
-    ::z/class ["paragraph" "content"]
-    ::z/style {:height "5rem"}
-    [:slot]]])
-```
-
-Use `zero.config/reg-components` to actually setup the web component:
-```clojure
-(zc/reg-components
-  :example/component
-  {:props #{:heading}
-   :view my-view})
-```
-
-Now we can use this in several ways:
-- Directly in our HTML
-  ```html
-  <example-component heading="Something">Some content inside</example-component>
-  ```
-- Via JavaScript some other UI framework
-  ```javascript
-    const el = document.createElement("example-component")
-    el.heading = "Something"
-    el.innerHTML = "Some content inside"
-  ```
-- From another Zero component
-  ```clojure
-  [:example/component :heading "Something" "Some content inside"]
-  ```
-
-Zero components can also make use of some primitive state management tools provided
-in `zero.core`.  Here's an example using all three of them:
-
-```clojure
-(ns example
-  (:require
-    [zero.core :refer [act bnd <<] :as z]
-    [zero.config :as zc]))
-
-(defn counter-view []
-  [:div
-   [:input :disabled true :value (bnd ::count)]
-   [:button ::z/on {:click (act [::reset])} (<< ::reset-text)]])
-
-(defonce !count (atom nil))
-
-(zc/reg-streams
-  ::count
-  (fn [rx]
-    (let [interval (js/setInterval #(swap! !count inc) 1000)]
-      (reset! !count 0)
-      (rx @!count)
-      (add-watch !count ::count (fn [_ _ _ v] (rx v)))
-    
-      ;; cleanup when the stream winds down
-      (fn count-stream-cleanup []
-        (js/clearInterval interval)))))
-
-(zc/reg-effects
-  ::reset
-  (fn []
-    (reset! !count 0)))
-
-(zc/reg-injections
-  ::reset-text
-  (fn []
-    "Reset"))
-
-(zc/reg-components
-  :example/counter
-  {:view counter-view})
-```
-
-**Actions**, created with `(act ...effects)`, consist of a sequence of effects to be
-invoked when the action is dispatched/called.  Though normal functions can be
-used as event handlers, actions should be preferred when possible as they make
-for cleaner, more declarative markup; and they have value semantics, so Zero
-can optimize by only updating event listeners when the actual value (not
-instance) changes.
-
-**Bindings**, created with `(bnd stream-key ...args)`, can be given as element props in
-place of normal values.  Instead of being passed through to the element instance,
-Zero will bind the property to the Binding's underlying data stream (identified by `stream-key`).
-So when said data stream publishes an update; any bound props will also update reactively.
-
-**Injections**, created with `(<< injector-key ...args)`, are substituted with the
-value returned from the registered injection handler.
-
-## More Docs
-
-- [Configuration](doc/Configuration.md) - Full walkthrough of `zero.config`, which is used to configure all aspect of Zero,
-  including registering components, effects, and streams.
-- [Markup](doc/Markup.md) - Detailed description of the markup notation used by Zero.
-- [Extras](doc/Extras.md) - Goes through Zero's 'extra' modules, including derived streams and the built-in database implementation.
+In addition, I'll do my best to keep the following up to date:
+- [Configuration](doc/Configuration.md) - Full walkthrough of `zero.config`,
+  which is used to configure all aspect of Zero, including registering
+  components.
+- [Markup](doc/Markup.md) - Detailed description of the markup
+  notation used by Zero, which is akin to Hiccup, but not identical.
+- [Extras](doc/Extras.md) - Goes through Zero's 'extra' modules,
+  including derived streams and the built-in database implementation.
 
 ## Contact
 - [zero@raystubbs.me](mailto:zero@raystubbs.me)

--- a/doc/Configuration.md
+++ b/doc/Configuration.md
@@ -40,10 +40,6 @@ pairs, with the `:view` option being the only one required.  Here's what each op
     for components that wrap native input elements.
   + `:self` - Causes Zero to attach an implicit `tabIndex = 0` to instances of the component if the field hasn't
     been set to something else explicitly.  This makes the component focusable.
-  + `:derive` - Zero uses Clojure's hierarchy system for configuring some component specific setup.  If the component
-    name is namespaced (e.g `:example/foo`) then Zero will automatically `derive` the component name from `example/Component`
-    (in an internal hierarchy), so components under a particular namespace can be configured in bulk.  This property
-    allows the component's parent to be given explicitly.  Ignored if the component name isn't namespaced.
 
 Here's an example:
 ```clojure
@@ -68,19 +64,7 @@ Here's an example:
 TODO
 
 ## Harvesting Events
-To maintain consistency between throttled and unthrottled actions, and avoid some issues that come with propagating
-events through shadow DOMs, Zero usually waits until the event that triggered an action is stale before evaluating
-an actions injections, or dispatching its side effects.  But often the data an event contains will change or become
-inaccessible as it propagates through the DOM; so we need a way to capture said data preemptively.  By default, Zero
-will do its best to harvest the most interesting data from event types it knows about, this data is made available
-in the `z.event/data` property of an action's context.  But Zero's built-in event harvesting capabilities will
-inevitably fall short.  The event harvesting for a particular event `.type` can be overridden by implementing a
-`zc/harvet-event` method for said type.
-
-```clojure
-(defmethod zc/harvest-event :input [^js/Event ev]
-  (-> ev .-target .-value))
-```
+TODO
 
 ## Data Streams and Bindings
 TODO: make this better

--- a/doc/Extras.md
+++ b/doc/Extras.md
@@ -5,71 +5,11 @@ for their particular project; without introducing a lot of unnecessary fluff.
 
 But for many projects, our requirements aren't that complicated, and we don't need to
 build everything custom.  It's sometimes nice to just have what we need to get started
-on a project, without doing a lot of groundwork. So Zero also comes with a set of optional
-extras in `zero.extras.*`, which may make building with Zero that much easier.
+on a project, without doing a lot of extra groundwork. So Zero also comes with a set of
+optional extras in `zero.extras.*`, which may make building with Zero that much easier.
 
 ## `zero.extras.util`
-This module sets up a basic set of Zero registrations, as well providing some useful
-utility functions.
-
-### Injections
-
-- `:ze/ctx`
-  
-  Resolves a path against the injector context.  So `(<< :ze/ctx :zero.core/host)` grabs
-  `:zero.core/host` from the context, and `(<< :ze/ctx :zero.core/event.data :foo)` does
-  `(get-in ctx [:zero.core/event.data :foo])`.
-
-
-- `:ze/<<`
-  
-  Injects an _injection_.  This creates a level of indirection.  Useful to avoid resolving the
-  inner injection on action dispatch, when passing markup into an action's effect.  This comes
-  with a utility function `<<<` which offers better aesthetics.  So `(<<< :something)` is
-  equivalent to `(<< :ze/<< :something)`.
-
-
-- `:ze/act`
-  
-  Injects an _action_.  This is useful when passing markup that includes nested actions that
-  depend on data from the constructing context, into an action's effect.  Since injections in
-  regular `(act ...)` actions will be resolved when said action is dispatched, in the dispatch
-  context; not the constructing context.  This also comes with a utility function `<<act` for
-  better aesthetics.  So `(<<act [:something (<< :foo)])` is equivalent to `(<< :ze/act [:something (<< :foo)])`.
-
-
-### Effects
-
-- `:ze/cond`
-  
-  Conditionally invokes effects.  Given a sequence of `[test ...effects]` vectors, invokes the
-  effects from the first truthy `test`.
-
-  ```clojure
-  (act [:ze/cond
-        [(<< :something?) [:do-something]]
-        [(<< :otherthing?) [:do-otherthing]]])
-  ```
-
-- `:ze/effects`
-
-  Takes and invokes a sequence of effects.
-
-  ```clojure
-  (act [:ze/effects [[:do-something] [:do-otherthing]]])
-  ```
-
-### Components
-
-- `:ze/echo`
-
-  A component which takes some Zero markup as a prop, and renders it.
-
-  ```clojure
-  [:ze/echo :vdom [:div "Hello, World!"]]
-  ```
-
-### Functions
+This module provides a few useful utility functions.
 
 - `(derived f & deps)`
 
@@ -99,33 +39,6 @@ utility functions.
   
   Removes a watcher registered with `watch`.
 
-
-- `(css-selector selector)`
-
-  If given a keyword, converts the keyword of the form `:my.example/my-component#id.class1.class2`
-  into the appropriate CSS selector string; in this case `my\.example-my-component#id.class1.class2`.
-
-
-- `(slotted-elements-prop & {:keys [selector slots})`
-  
-  Creates a _state factory_ prop which produces a state object with a set of elements currently slotted
-  in `<slot>` elements within the component.  If a `selector` is provided, it's used to filter the
-  included elements.  If a `slots` option is given, only elements in slots with the given names
-  are included.  This is useful to allow a component's markup to react to whether an element is
-  currently slotted, or which kinds of elements are slotted in which slots.
-
-  ```clojure
-  (zc/reg-components
-    :my.example/foo
-    {:props {:slotted (zu/slotted-elements-prop)}
-     :view (fn [{:keys [slotted]}]
-             [:div
-              (if (seq slotted)
-                "Something's slotted"
-                "Nothing's slotted")
-              [:slot]])})
-  ```
-
 ## `zero.extras.db`
 Many modern UI frameworks are built around the concept of a single centralized in-memory DB on the front-end
 housing all FE business state.  This makes it trivial to display the same data in multiple places and formats
@@ -139,7 +52,7 @@ requirements include:
 - [datascript](https://github.com/tonsky/datascript)
 - [relic](https://github.com/wotbrew/relic)
 
-That said, this DB will probably work just fine for most basic projects.  The module exposes the following
+That said, this DB will probably work just fine for many basic projects.  The module exposes the following
 functions and registrations for interacting with the main DB.
 
 - `(get path)`
@@ -162,15 +75,15 @@ functions and registrations for interacting with the main DB.
   - `:fn`, `:args` - Apply `op-payload` (should be a function) to the current path value and any extra args given 
      in `:args`.
 
-- `(<< :ze.db/path path)`
+- `(<< ::db/path path)`
 
   Injects the value at `path` in the DB.
 
-- `(bnd :ze.db/path path)`
+- `(bnd ::db/path path)`
 
   Tracks the current value at `path` in the DB.
 
-- `(act [:ze.db/patch patch])`
+- `(act [::db/patch patch])`
 
   Applies `patch` to the DB.  Equivalent to `(patch! patch)`.
 
@@ -178,7 +91,6 @@ In addition, the `(apply-patch m patch)` function, which implements the DB's pat
 any map, is exposed to allow for implementing other DBs with the same patch notation.  This function returns
 `[patched-m affected-paths]`.
 
-
 ## More to come
-More utilities will likely be added to Zero extras in the future.  Open an issue if you'd like to make
-a request.
+More utilities will likely be added to Zero extras in the future.
+Open an issue if you'd like to make a request.

--- a/doc/Markup.md
+++ b/doc/Markup.md
@@ -37,7 +37,7 @@ property name (the prop name converted to cammelCase) then that property will be
 set to the prop value, otherwise the value will be stringified and set as an attribute
 on the element, with the same name as the prop.
 
-As a convenient short-hand, an ID and classes can be included in the node's tag.
+As a convenient shorthand, an ID and classes can be included in the node's tag.
 ```clojure
 [:div#my-thing.foo.bar "I'm a DIV"]
 ```
@@ -78,6 +78,12 @@ This prop allows event handlers to be declaratively attached to the target eleme
 ```
 
 Either keywords or strings can be used for the event name, but they shouldn't be mixed.
+
+### `:zero.core/bind`
+This should be given as a map of `prop-name -> watchable`.  The `watchable` will
+be bound to the named prop; so when its value changes, so the prop will be updated
+accordingly.  If the `watchable` can also be deref'd, then it'll be deref'd for
+an initial value.
 
 ### `:zero.core/style`
 This prop allows an inline style for the element to be given as a map.

--- a/src/zero/config.cljc
+++ b/src/zero/config.cljc
@@ -27,7 +27,7 @@
 
          ("input" "change")
          (let [target (.-target event)]
-           (when (instance? js/HTMLInputElement target)
+           (when (or (instance? js/HTMLInputElement target) (instance? js/HTMLTextAreaElement target))
              (case (.-type target)
                "checkbox"
                (.-checked target)
@@ -36,6 +36,11 @@
                (-> target .-files array-seq vec)
 
                (.-value target))))
+
+         "submit"
+         (let [target (.-target event)]
+           (when (instance? js/HTMLFormElement target)
+             (js/FormData. target)))
 
          ("drop")
          (->> event .-dataTransfer .-items array-seq

--- a/src/zero/core.cljc
+++ b/src/zero/core.cljc
@@ -3,9 +3,12 @@
    [zero.impl.actions :as act #?@(:cljs [:refer [Action]])]
    [zero.impl.bindings #?@(:cljs [:refer [Binding]])]
    [zero.impl.injection #?@(:cljs [:refer [Injection]])]
+   [zero.impl.base #?@(:cljs [:refer [IDisposable dispose!]])]
+   [zero.impl.logger :as log]
    [zero.impl.markup :as markup]
-   #?(:cljs [zero.impl.components])
-   [zero.config :as config])
+   #?(:cljs [zero.impl.components :as c])
+   [zero.config :as config]
+   [clojure.string :as str])
   #?(:clj
      (:import
        (zero.impl.actions Action)
@@ -184,3 +187,178 @@ for a component with this name.
 (defn map->bnd
   [m]
   (Binding. (into {} (:props m)) (:key m) (vec (:args m))))
+
+(defn css-selector [x]
+  (cond
+    (string? x)
+    x
+
+    (keyword? x)
+    (if-let [ns (namespace x)]
+      (str (str/replace ns #"[.]" "\\.") "-" (name x))
+      (name x))
+    
+    (vector? x)
+    (str/join " " (map css-selector x))))
+
+(defn <<act [& args]
+  (apply << ::act args))
+
+(defn <<ctx [& path]
+  (apply << ::ctx path))
+
+(defn <<< [& args]
+  (apply << ::<< args))
+
+#?(:cljs
+   (do
+     (defn bind [k ^js/Node dom prop-name watchable]
+       (c/bind k dom prop-name watchable))
+     
+     (defn unbind [k]
+       (c/unbind k))
+     
+     (defn listen [k ^js/Node dom-or-doms event-name listener-fn & {:keys [once? capture? passive? signal] :as opts}]
+       (c/listen k dom-or-doms event-name listener-fn opts))
+     
+     (defn unlisten [k]
+       (c/unlisten k)) 
+     
+     (config/reg-effects
+       ::cond
+       (fn [& clauses]
+         (let [paired-clauses (partition-all 2 clauses)]
+           (loop [remaining paired-clauses]
+             (if (empty? remaining)
+               nil
+               (let [[test action :as clause] (first remaining)]
+                 (when (not= 2 (count clause))
+                   (throw (ex-info "Uneven number of items in :zero.core/cond" {:items clauses})))
+                 (if test
+                   (action {})
+                   (recur (rest remaining))))))))
+       
+       ::case
+       (fn [v & {:as cases}]
+         (when-let [action (get cases v (get cases :default))]
+           (action {})))
+       
+       ::listen c/listen
+       ::unlisten c/unlisten
+       ::bind c/bind
+       ::unbind c/unbind)
+     
+     (config/reg-injections
+       ::ctx
+       (fn [ctx & path]
+         (get-in ctx path))
+
+       ::act
+       (fn [_ & args]
+         (apply act args))
+
+       ::<<
+       (fn [_ & args]
+         (apply << args))
+
+       ::select-doms
+       (fn [{root ::root} selector & {:keys [^js/Node from default]}]
+         (or
+           (some-> (.querySelectorAll (or from root) (css-selector selector)) vec not-empty)
+           default))
+
+       ::select-dom
+       (fn [{root ::root} selector & {:keys [^js/Node from default]}]
+         (or
+           (some-> (.querySelector (or from root) (css-selector selector)))
+           default))
+
+       ::host-parent-dom
+       (fn [{^js/Node host ::host}]
+         (.-parentElement host))
+       
+       ::host-root-dom
+       (fn [{^js/Node host ::host}]
+         (.getRootNode host)))
+
+     (config/reg-components
+       ::echo
+       {:props #{:vdom}
+        :view (fn [{:keys [vdom]}]
+                vdom)}
+       
+       ::listen
+       {:props #{:sel :evt :act}
+        :view (fn [{:keys [sel evt] action :act :as props}]
+                [:root>
+                 ::style {:display "none"}
+                 ::on {:connect (act
+                                  [::listen
+                                   (<<ctx ::host)
+                                   (<< ::select-doms sel :from (<< ::host-root-dom) :default (<< ::host-parent-dom))
+                                   evt action])
+                       :update (act
+                                 [::unlisten (<<ctx ::host)]
+                                 [::listen
+                                  (<<ctx ::host)
+                                  (<< ::select-doms sel :from (<< ::host-root-dom) :default (<< ::host-parent-dom))
+                                  evt action])
+                       :disconnect (act [::unlisten (<<ctx ::host)])}])}
+       
+       ::bind
+       {:props #{:sel :prop :ref}
+        :view (fn [{:keys [sel prop ref]}]
+                [:root>
+                 ::style {:display "none"}
+                 ::on {:connect (act
+                                  [::bind
+                                   (<<ctx ::host)
+                                   (<< ::select-dom sel :from (<< ::host-root-dom) :default (<< ::host-parent-dom))
+                                   prop ref])
+                       :update (act
+                                 [::unbind (<<ctx ::host)]
+                                 [::bind
+                                  (<<ctx ::host)
+                                  (<< ::select-dom sel :from (<< ::host-root-dom) :default (<< ::host-parent-dom))
+                                  prop ref])
+                       :disconnect (act [::unbind (<<ctx ::host)])}])})
+     
+     (defn slotted-prop [& {:keys [selector slots]}]
+       (let [slotted-selector (some-> selector css-selector)
+             slot-selector (if slots (->> slots (map #(str "slot[name=\"" (name %) "\"]")) (str/join ",")) "slot")]
+         {:state-factory
+          (fn slotted-prop-state-factory [^js/HTMLElement dom]
+            (let [shadow (.-shadowRoot dom)
+                  !slotted (atom nil)
+                  update-slotted! (fn update-slotted! []
+                                    (let [now-slotted (set
+                                                        (for [slot (array-seq (.querySelectorAll shadow slot-selector))
+                                                              node (array-seq (.assignedNodes slot))
+                                                              :when (or (nil? slotted-selector) (and (instance? js/HTMLElement node) (.matches node slotted-selector)))]
+                                                          node))]
+                                      (when (not= now-slotted @!slotted)
+                                        (reset! !slotted now-slotted))))
+                  abort-controller (js/AbortController.)]
+              (update-slotted!)
+     
+              (.addEventListener shadow "slotchange" update-slotted! #js{:signal (.-signal abort-controller)})
+              #_(.addEventListener shadow "render" update-slotted! #js{:signal (.-signal abort-controller)})
+     
+              (reify
+                IDeref
+                (-deref [_]
+                  @!slotted)
+     
+                IWatchable
+                (-add-watch [_ k f]
+                  (-add-watch !slotted k f))
+                (-remove-watch [_ k]
+                  (-remove-watch !slotted k))
+     
+                IDisposable
+                (dispose! [_]
+                  (.abort abort-controller)))))
+     
+          :state-cleanup
+          (fn slotted-prop-state-cleanup [state _]
+            (dispose! state))}))))

--- a/src/zero/extras/db.cljc
+++ b/src/zero/extras/db.cljc
@@ -1,4 +1,5 @@
 (ns zero.extras.db
+  (:refer-clojure :exclude [get])
   (:require
     [zero.config :as zc]))
 

--- a/src/zero/extras/dom.cljs
+++ b/src/zero/extras/dom.cljs
@@ -56,6 +56,9 @@
                                 (.abort aborter))
                               (let [aborter (js/AbortController.)
                                     target-doms (cond
+                                                  (nil? target)
+                                                  [(-> ev .-target .-host .-parentElement)]
+
                                                   (instance? js/Node target)
                                                   [target]
 

--- a/src/zero/extras/dom.cljs
+++ b/src/zero/extras/dom.cljs
@@ -1,4 +1,4 @@
-(ns zero.extras.dom
+(ns ^:deprecated zero.extras.dom
   (:require
    [zero.core :as z]
    [zero.config :as zc]
@@ -43,11 +43,9 @@
 (zc/reg-components
   ::echo
   {:inherit-doc-css? true
-   :props #{:vdom :vdom-ref}
-   :view (fn [{:keys [vdom vdom-ref]}]
-           (if (can-watch? vdom-ref)
-             [::echo :vdom vdom-ref]
-             vdom))}
+   :props #{:vdom}
+   :view (fn [{:keys [vdom]}]
+           vdom)}
 
   ::listen
   {:props #{:target :event :action}

--- a/src/zero/extras/util.cljc
+++ b/src/zero/extras/util.cljc
@@ -6,6 +6,7 @@
    [zero.impl.base :refer [try-catch try-deref]]
    [zero.impl.logger :as log]))
 
+;; deprecated
 (zc/reg-injections
   ::ctx
   (fn [context & path]
@@ -19,6 +20,7 @@
   (fn [_ & args]
     (apply z/<< args)))
 
+;; deprecated
 (zc/reg-effects
   ::cond
   (fn [& cases]
@@ -29,13 +31,13 @@
   (fn [effects]
     ((apply z/act effects) nil)))
 
-(defn <<act [& args]
+(defn ^:deprecated <<act [& args]
   (apply z/<< ::act args))
 
-(defn <<ctx [& path]
+(defn ^:deprecated <<ctx [& path]
   (apply z/<< ::ctx path))
 
-(defn <<< [& args]
+(defn ^:deprecated <<< [& args]
   (apply z/<< ::<< args))
 
 (defn derived [f & deps]
@@ -87,12 +89,4 @@
       (fn [_ _ _ new-val]
         (on-deps new-val)))))
 
-(defn css-selector [x]
-  (cond
-    (string? x)
-    x
-
-    (keyword? x)
-    (if-let [ns (namespace x)]
-      (str (str/replace ns #"[.]" "\\.") "-" (name x))
-      (name x))))
+(def ^:deprecated css-selector z/css-selector)

--- a/src/zero/impl/base.cljc
+++ b/src/zero/impl/base.cljc
@@ -62,5 +62,6 @@
   (dispose! [disposable]))
 
 (defn named? [x]
-  #?(:cljs (satisfies? INamed x)
-     :clj (instance? Named x)))
+  (or (string? x)
+    #?(:cljs (satisfies? INamed x)
+       :clj (instance? Named x))))

--- a/src/zero/impl/base.cljc
+++ b/src/zero/impl/base.cljc
@@ -1,7 +1,10 @@
 (ns zero.impl.base
   #?(:cljs (:require-macros zero.impl.base))
   (:require
-   [clojure.string :as str]))
+   [clojure.string :as str])
+  #?(:clj
+     (:import
+       (clojure.lang Named))))
 
 (defn words [s]
   (str/split s #"\s+|(?<=[^_-])[_-]+(?=[^_-])|(?<=[a-z])(?=[A-Z])|(?<=[A-Z])(?=[A-Z][a-z])"))
@@ -57,3 +60,7 @@
 
 (defprotocol IDisposable
   (dispose! [disposable]))
+
+(defn named? [x]
+  #?(:cljs (satisfies? INamed x)
+     :clj (instance? Named x)))

--- a/src/zero/impl/components.cljs
+++ b/src/zero/impl/components.cljs
@@ -370,8 +370,10 @@
                               child-dom)
 
                             :else
-                            (let [child-dom (take-text-dom)]
-                              (set! (.-nodeValue child-dom) (str vnode))
+                            (let [child-dom (take-text-dom)
+                                  text-value (str vnode)]
+                              (when-not (identical? (.-nodeValue child-dom) text-value)
+                                (set! (.-nodeValue child-dom) text-value))
                               child-dom)))
                         children)
 

--- a/src/zero/impl/components.cljs
+++ b/src/zero/impl/components.cljs
@@ -20,7 +20,6 @@
 
 (defonce ^:private PROPS-SYM (js/Symbol "zProps"))
 (defonce ^:private LISTENER-ABORT-CONTROLLERS-SYM (js/Symbol "zListenerAbortControllers"))
-(defonce ^:private MARK-SYM (js/Symbol "zMark"))
 (defonce ^:private HTML-NS "http://www.w3.org/1999/xhtml")
 (defonce ^:private SVG-NS "http://www.w3.org/2000/svg")
 (defonce ^:private PRIVATE-SYM (js/Symbol "zPrivate"))

--- a/src/zero/impl/markup.cljc
+++ b/src/zero/impl/markup.cljc
@@ -53,7 +53,7 @@ tag.
   (extract-tag-props
     [:div#my-thing.foo.bar {:zero.core/class "something"} (list "body")]))
 
-
+;; TODO: remove this eventually
 (defn move-binds "
 Putting watchable things to be bound to props in place of the
 prop values is now deprecated.  Binds should now be put

--- a/src/zero/impl/markup.cljc
+++ b/src/zero/impl/markup.cljc
@@ -44,7 +44,7 @@ tag.
        (not (str/blank? id)) (assoc :id (subs id 1))
        (not (str/blank? classes)) (assoc :zero.core/class
                                     (->> [(some-> classes (str/split #"[.]")) (:zero.core/class props)]
-                                      flatten (remove str/blank?) not-empty)))
+                                      flatten (map name) (remove str/blank?) vec not-empty)))
      body]
     (throw (ex-info "Invalid tag" {:tag tag}))))
 

--- a/src/zero/impl/markup.cljc
+++ b/src/zero/impl/markup.cljc
@@ -1,6 +1,7 @@
 (ns zero.impl.markup
   (:require
-    [clojure.string :as str]))
+   [clojure.string :as str]
+   [zero.impl.base :refer [can-watch?]]))
 
 (defn flatten-body [body]
   (mapcat
@@ -52,13 +53,27 @@ tag.
   (extract-tag-props
     [:div#my-thing.foo.bar {:zero.core/class "something"} (list "body")]))
 
+
+(defn move-binds "
+Putting watchable things to be bound to props in place of the
+prop values is now deprecated.  Binds should now be put
+into `::z/bind`.  However, to avoid breaking existing
+code; we'll automatically move any watchable things found in
+the props into the `::z/bind` map.
+" [props]
+  (let [{binds true other false} (group-by can-watch? props)]
+    (cond-> (into {} other)
+      (seq binds)
+      (update :zero.core/bind (fnil into {}) binds))))
+
 (defn preproc-vnode "
 Simplifies the vnode, parsing out the classes and id from
 the tag, and converting compound tags (i.e `[:div :span]`)
 into nested vnodes, and accumulating the whole body into
 one sequence.
 " [vnode]
-  (let [[tag-or-tags props body] (normalize-vnode vnode)]
+  (let [[tag-or-tags props body] (normalize-vnode vnode)
+        props (move-binds props)]
     (->
       (cond
         (keyword? tag-or-tags)


### PR DESCRIPTION
Lots of changes in this PR, including:
- Handling keywords as classes in `::z/class`
- Handling `::z/internals` properties (and `:form-associated?` component option)
- Copy some functionality from `zero.extras.util` into `zero.core`
    - Will leave the existing ones in place for now, for backward compatibility, but should remove them eventually
- Change how bindings are handled (should now go in `::z/bind` instead of as a top-level prop)
   - Existing functionality will be preserved for now, internally Zero will move any watchable props into `::z/bind`
- Add a few features to help with SSR
