### PR TITLE
Express State Management Options in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ You can render this button wherever you choose: in React, Svelte, pure HTML. It 
 This can be implemented a few different ways. We will consider several examples, moving from the low level to the high level.
 
 ### Manual Event Handling
-Zero can make custom component's HTML attributes reactive. Similar to React's notion that a view is a function of its props, we can render a web component as a function of its attributes.
+Zero makes custom component reactive. Similar to React's notion that a view is a function of its props, we can render a web component as a function of its properties.
 
 
 ```clojurescript
@@ -68,9 +68,10 @@ Zero can make custom component's HTML attributes reactive. Similar to React's no
                        :props #{:clicks}})
 ```
 
-When we register our component, we declare `clicks` as a reactive attribute. When we the `incrementing-button`'s `clicks` attribute is updated, it will re-render.
+When we register our component, we declare `clicks` as a prop. When we update the `incrementing-button`'s `clicks` property, it will re-render.
 
-We use the `zero.core/on` our root component to listen for click events. When the click occurs, `on-click` is called, and it increments the `incrementing-button`'s `clicks` attribute. Zero automatically re-renders the `incrementing-button`.
+To update our component, we use use the `zero.core/on` prop on the root to listen for click events. When the click occurs, `on-click` is called, and it increments the `incrementing-button`'s `clicks` property. `incrementing-button` re-renders automatically.
+
 
 ### Actions
 (This example will be similar to the previous, except it will use actions to eliminate some boilerplate around finding the host.)

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ You can render this button wherever you choose: in React, Svelte, pure HTML. It 
 This can be implemented a few different ways. We will consider several examples, moving from the low level to the high level.
 
 ### Manual Event Handling
-Zero can make custom component's HTML attributes reactive. Similar to React's notion that a view is a function of its props, we can implement HATEOS in a reactive way.
+Zero can make custom component's HTML attributes reactive. Similar to React's notion that a view is a function of its props, we can render a web component as a function of its attributes.
 
 
 ```clojurescript

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Let's show the different options using the same example: an incrementing button.
 You can render this button wherever you choose: in React, Svelte, pure HTML. It looks like this:
 
 ```html
-<increment-button count="0"></increment-button>
+<increment-button clicks="0"></increment-button>
 ```
 
 This can be implemented a few different ways. We will consider several examples, moving from the low level to the high level.

--- a/README.md
+++ b/README.md
@@ -72,12 +72,38 @@ When we register our component, we declare `clicks` as a prop. When we update th
 
 To update our component, we use use the `zero.core/on` prop on the root to listen for click events. When the click occurs, `on-click` is called, and it increments the `incrementing-button`'s `clicks` property. `incrementing-button` re-renders automatically.
 
+### Atom
+
+We can also use ClojureScript's built-in tools for state. Let's look at an example using an atom.
+
+```clojurescript
+(ns increment-counter
+  (:require [zero.core :as z]
+            [zero.config :as zc]
+            [zero.component]))
+
+(defonce clicks*
+  (atom 0))
+
+(defn on-click
+  [_event]
+  (swap! clicks* inc))
+
+(defn button-view
+  [{:keys [clicks]}]
+  [:root> {::z/on {:click on-click}}
+   [:button (str "Clicked " clicks " times")]])
+
+(zc/reg-components
+ :incrementing-button {:view button-view
+                       :props {:clicks clicks*}})
+```
+
+Here we have bound the `clicks` prop to an atom. Similar to reagent, when that atom updates, our `incrementing-button` component re-renders.
 
 ### Actions
 (This example will be similar to the previous, except it will use actions to eliminate some boilerplate around finding the host.)
 
-### Atom
-(this example uses a Clojurescript atom to store the state)
 
 ### App DB
 (re-frame-esque example)

--- a/README.md
+++ b/README.md
@@ -29,6 +29,61 @@ A toolkit for building web components in Clojure and ClojureScript.
 - Web components are cool, but the native API for building them isn't very convenient
     - Zero makes web components easy
 
+## Reactive State
+Zero gives you tools for reactive state. You can choose to stick close to the DOM, following HATEOS principles. You can use a central in-memory application database similar to re-frame. Or you can choose from intermediate options -- how you manage state is up to you.
+
+Let's show the different options using the same example: an incrementing button. We want a button that reads "Clicked 0 Times". Every time you click it, it should increment the counter.
+
+You can render this button wherever you choose: in React, Svelte, pure HTML. It looks like this:
+
+```html
+<increment-button count="0"></increment-button>
+```
+
+This can be implemented a few different ways. We will consider several examples, moving from the low level to the high level.
+
+### Manual Event Handling
+Zero can make custom component's HTML attributes reactive. Similar to React's notion that a view is a function of its props, we can implement HATEOS in a reactive way.
+
+
+```clojurescript
+(ns increment-counter
+  (:require [zero.core :as z]
+            [zero.config :as zc]
+            [zero.component]))
+
+(defn- on-click
+  [event]
+  (let [increment-button (-> event (.-currentTarget) (.-host))
+        clicks (some-> (.getAttribute increment-button "clicks")
+                       (js/parseInt)
+                       inc
+                       str)]
+    (.setAttribute increment-button "clicks" clicks)))
+
+(defn button-view
+  [{:keys [clicks]}]
+  [:root> {::z/on {:click on-click}}
+   [:button (str "Clicked " clicks " times")]])
+
+(zc/reg-components
+ :incrementing-button {:view button-view
+                       :props #{:clicks}})
+```
+
+When we register our component, we declare `clicks` as a reactive attribute. When we the `incrementing-button`'s `clicks` attribute is updated, it will re-render.
+
+We use the `zero.core/on` our root component to listen for click events. When the click occurs, `on-click` is called, and it increments the `incrementing-button`'s `clicks` attribute. Zero automatically re-renders the `incrementing-button`.
+
+### Actions
+(This example will be similar to the previous, except it will use actions to eliminate some boilerplate around finding the host.)
+
+### Atom
+(this example uses a Clojurescript atom to store the state)
+
+### App DB
+(re-frame-esque example)
+
 ## Warning
 Depends on modern browser APIs, works on the latest versions of all
 major browsers... but will break in some not-so-old versions.  In particular,

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Zero also provides facilities for state management that resemble re-frame.
                        :props {:clicks (z/bnd ::db/path [:clicks])}})
 ```
 
-Here we have an in-memory database for our application. We bind our clicks prop to a path in the database, and then use the `::db/path` effect to update the value at the `:clicks` path.
+Here we have an in-memory database for our application. We bind our clicks prop to a path in the database, and then use the `::db/patch` effect to update the value at the `:clicks` path.
 
 ### And Beyond
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ When we register our component, we declare `clicks` as a prop. When we update th
 
 To update our component, we use use the `zero.core/on` prop on the root to listen for click events. When the click occurs, `on-click` is called, and it increments the `incrementing-button`'s `clicks` property. `incrementing-button` re-renders automatically.
 
-### Atom
+### Atoms
 
 We can also use ClojureScript's built-in tools for state. Let's look at an example using an atom.
 
@@ -101,12 +101,38 @@ We can also use ClojureScript's built-in tools for state. Let's look at an examp
 
 Here we have bound the `clicks` prop to an atom. Similar to reagent, when that atom updates, our `incrementing-button` component re-renders.
 
-### Actions
-(This example will be similar to the previous, except it will use actions to eliminate some boilerplate around finding the host.)
-
-
 ### App DB
-(re-frame-esque example)
+
+Zero also provides facilities for state management that resemble re-frame.
+
+```clojurescript
+(ns increment-counter.client
+  (:require [zero.core :as z]
+            [zero.config :as zc]
+            [zero.component]
+            [zero.extras.db :as db]))
+
+;; Init db value
+(db/patch! [{:path [:clicks] :value 0}])
+
+(defn button-view
+  [{:keys [clicks]}]
+  [:root> {::z/on {:click (z/act [::db/patch [{:path [:clicks]
+                                               :fn inc}]])}}
+   [:button (str "Clicked " clicks " times")]])
+
+(zc/reg-components
+ :incrementing-button {:view button-view
+                       :props {:clicks (z/bnd ::db/path [:clicks])}})
+```
+
+Here we have an in-memory database for our application. We bind our clicks prop to a path in the database, and then use the `::db/path` effect to update the value at the `:clicks` path.
+
+### And Beyond
+
+Zero aims to be both simple and easy. It gives you options to follow familiar patterns for state management. But it also gives you the flexibility to manage state as you need to.
+
+For more details, check out the [User's Guide](doc/UsersGuide.md). The SSR Demo application provides further examples of Zero's state management.
 
 ## Warning
 Depends on modern browser APIs, works on the latest versions of all

--- a/README.md
+++ b/README.md
@@ -52,14 +52,11 @@ Zero can make custom component's HTML attributes reactive. Similar to React's no
             [zero.config :as zc]
             [zero.component]))
 
-(defn- on-click
+(defn on-click
   [event]
-  (let [increment-button (-> event (.-currentTarget) (.-host))
-        clicks (some-> (.getAttribute increment-button "clicks")
-                       (js/parseInt)
-                       inc
-                       str)]
-    (.setAttribute increment-button "clicks" clicks)))
+  (let [increment-button (.-host (.-currentTarget event))
+        clicks           (js/parseInt (.-clicks increment-button))]
+    (set! (.-clicks increment-button) (inc clicks))))
 
 (defn button-view
   [{:keys [clicks]}]


### PR DESCRIPTION
Problem
-------
Visitors to Zero's repository would benefit from seeing very basic examples of building stateful components, so that they can see what using Zero looks like.

Solution
--------
Use the simple example of an incrementing button to show the different options for managing state.