### PR TITLE
Basic declarative shadow DOM support

### DIFF
--- a/src/zero/component.cljs
+++ b/src/zero/component.cljs
@@ -582,7 +582,8 @@
           #js{:value
               (fn []
                 (let [^js this (js* "this")
-                      ^js shadow (.attachShadow this #js{:mode "open" :delegatesFocus (= focus :delegate)})
+                      ^js shadow (or (.-shadowRoot this)
+                                   (.attachShadow this #js{:mode "open" :delegatesFocus (= focus :delegate)}))
                       !instance-state (atom
                                         {:shadow shadow
                                          :internals (.attachInternals this)


### PR DESCRIPTION
VNodes for Zero components found in the markup passed to `zero.html/html` will get a declarative shadow DOM injected.

For now it's pretty basic, but we can probably extend this functionality as use cases come up.  Don't want to over-implement it in the wrong direction.